### PR TITLE
Lots o' stuff

### DIFF
--- a/justfile
+++ b/justfile
@@ -6,3 +6,9 @@ minimal-versions:
 
 install-default-config:
 	cp odin.yaml ~/.config/odin.yaml
+
+injstall:
+	cargo install --force --path .
+
+clippy:
+	cargo clippy

--- a/odin.yaml
+++ b/odin.yaml
@@ -1,12 +1,17 @@
+root: true
+
 templates:
-  github: https://github.com/search?q={{query}}
-  google: https://www.google.com/search?q={{query}}
-  rustup-stdlib: file://{{cmd(bin="rustup", args=["doc", "--std", "--path"])}}
-  rust-stdlib: https://doc.rust-lang.org/std/?search={{query}}
-  stack-overflow: https://stackoverflow.com/search?q={{query}}
+  crates-io: https://crates.io/search?q={{args | join}}
+  github: https://github.com/search?q={{args | join}}
+  google: https://www.google.com/search?q={{args | join}}
+  rust-stdlib: https://doc.rust-lang.org/std/?search={{args | join}}
+  stack-overflow: https://stackoverflow.com/search?q={{args | join}}
+  thesaurus: https://www.thesaurus.com/browse/{{args | join}}
 
 aliases:
-  gh: github
+  ci: crates-io
   gg: google
+  gh: github
   rs: rust-stdlib
   so: stack-overflow
+  th: thesaurus

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,29 +1,34 @@
+// stdlib
 pub(crate) use std::{
   collections::{BTreeMap, HashMap},
-  env,
-  fs::File,
-  io::{self, Read},
+  env, fs, io,
   iter::FromIterator,
   path::{Path, PathBuf},
   process::{Command, ExitStatus},
   str,
 };
 
+// dependencies
 pub(crate) use serde::de::DeserializeOwned;
-pub(crate) use serde_derive::Deserialize;
+pub(crate) use serde_derive::{Deserialize, Serialize};
 pub(crate) use structopt::StructOpt;
-pub(crate) use tera::Tera;
+pub(crate) use tera::{Tera, Value};
 pub(crate) use url::Url;
 pub(crate) use xdg::{BaseDirectories, BaseDirectoriesError};
 
+// constants
+pub(crate) use crate::default_config::DEFAULT_CONFIG;
+
 // structs and enums
 pub(crate) use crate::{
-  config::Config, context::Context, error::Error, fn_cmd::FnCmd, fn_env::FnEnv, opt::Opt,
+  config::Config, context::Context, error::Error, fn_cmd::FnCmd, fn_env::FnEnv, ft_join::FtJoin,
+  location::Location, opt::Opt, query::Query, subcommand::Subcommand,
   template_parse_error::TemplateParseError,
 };
 
 // traits
-pub(crate) use crate::function::Function;
+pub(crate) use crate::{filter::Filter, function::Function};
 
+// testing
 #[cfg(test)]
 pub(crate) use crate::testing::{self, common::*};

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,50 +1,76 @@
 use crate::common::*;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Default, Eq, PartialEq, Debug)]
 #[serde(deny_unknown_fields)]
+#[serde(default)]
 pub(crate) struct Config {
-  pub(crate) aliases: Option<BTreeMap<String, String>>,
+  pub(crate) root: bool,
+  #[serde(skip)]
+  pub(crate) parent: Option<Box<Config>>,
   pub(crate) templates: BTreeMap<String, String>,
+  pub(crate) aliases: BTreeMap<String, String>,
 }
 
 impl Config {
   pub(crate) const FILE_NAME: &'static str = "odin.yaml";
 
-  /// Instantiate config from YAML file at `path`
-  pub(crate) fn load(path: &Path) -> Result<Config, Error> {
-    let file = File::open(&path).map_err(|io_error| Error::ConfigIo {
+  pub(crate) fn load(override_path: Option<PathBuf>) -> Result<Config, Error> {
+    if let Some(override_path) = override_path {
+      Self::from_path(&override_path)
+    } else if let Some(config_path) = BaseDirectories::new()?.find_config_file(Self::FILE_NAME) {
+      Self::from_path(&config_path)
+    } else {
+      Self::from_yaml(DEFAULT_CONFIG, Location::name("default config"))
+    }
+  }
+
+  pub(crate) fn from_yaml(yaml: &str, location: impl Into<Location>) -> Result<Config, Error> {
+    let config = serde_yaml::from_str(yaml).map_err(|yaml_error| Error::ConfigDeserialize {
+      yaml_error,
+      location: location.into(),
+    })?;
+
+    Self::extend(config)
+  }
+
+  pub(crate) fn from_path(path: &Path) -> Result<Config, Error> {
+    let yaml = fs::read_to_string(&path).map_err(|io_error| Error::ConfigIo {
       path: path.to_owned(),
       io_error,
     })?;
 
-    Self::from_reader(file).map_err(|yaml_error| Error::ConfigDeserialize {
-      path: path.to_owned(),
-      yaml_error,
-    })
+    Self::from_yaml(&yaml, path)
   }
 
-  /// Instantiate config from reader
-  pub(crate) fn from_reader(reader: impl Read) -> Result<Config, serde_yaml::Error> {
-    serde_yaml::from_reader(reader)
+  fn extend(mut config: Config) -> Result<Config, Error> {
+    if !config.root {
+      let parent = Config::from_yaml(DEFAULT_CONFIG, Location::name("default config"))?;
+      config.parent = Some(Box::new(parent));
+    }
+
+    config.check()?;
+
+    Ok(config)
   }
 
-  /// Look up `name` in aliases and templates
-  pub(crate) fn resolve<'a>(&'a self, name: &'a str) -> Result<&'a str, Error> {
-    let template: &str = self
-      .aliases
-      .as_ref()
-      .map(|aliases| match aliases.get(name) {
-        Some(target) => target,
-        None => name,
-      })
-      .unwrap_or(name);
+  fn check(&self) -> Result<(), Error> {
+    for (name, target) in &self.aliases {
+      self.check_alias(name, target)?;
+    }
 
-    if !self.templates.contains_key(template) {
-      Err(Error::TemplateUnknown {
-        name: name.to_owned(),
-      })
+    Ok(())
+  }
+
+  fn check_alias(&self, name: &str, target: &str) -> Result<(), Error> {
+    if self.templates.contains_key(target) {
+      Ok(())
+    } else if let Some(parent) = &self.parent {
+      parent.check_alias(name, target)
     } else {
-      Ok(template)
+      Err(Error::AliasTargetUnknown {
+        name: name.to_string(),
+        target: target.to_string(),
+      })
     }
   }
 }
@@ -54,20 +80,94 @@ mod tests {
   use super::*;
 
   #[test]
-  fn resolve() -> Result<(), Error> {
+  fn root_has_no_parent() -> Result<(), Error> {
     let config = testing::config(
       "
-      templates:
-        foo: FOO
-
-      aliases:
-        bar: foo
+      root: true
     ",
     )?;
 
-    assert_eq!(config.resolve("foo")?, "foo");
-    assert_eq!(config.resolve("bar")?, "foo");
+    assert!(config.root);
+    assert!(config.parent.is_none());
+    assert!(config.templates.is_empty());
+    assert!(config.aliases.is_empty());
 
     Ok(())
   }
+
+  #[test]
+  fn child_has_parent() -> Result<(), Error> {
+    let config = testing::config(
+      "
+      root: false
+    ",
+    )?;
+
+    assert!(!config.root);
+    assert!(config.parent.is_some());
+    assert!(config.templates.is_empty());
+    assert!(config.aliases.is_empty());
+
+    Ok(())
+  }
+
+  #[test]
+  fn child_inherits_from_default() -> Result<(), Error> {
+    let config = testing::config(
+      "
+      root: false
+    ",
+    )?;
+
+    let parent = config.parent.unwrap();
+
+    let default = testing::config(DEFAULT_CONFIG)?;
+
+    assert_eq!(parent.as_ref(), &default);
+
+    Ok(())
+  }
+
+  #[test]
+  fn unknown_alias() -> Result<(), Error> {
+    let result = testing::config(
+      "
+      aliases:
+        foo: bar
+    ",
+    );
+
+    match result {
+      Err(Error::AliasTargetUnknown { name, target }) => {
+        assert_eq!(name, "foo");
+        assert_eq!(target, "bar");
+      }
+      Err(err) => panic!("unexpected error: {:?}", err),
+      Ok(ok) => panic!("expected error but got: {:?}", ok),
+    }
+
+    Ok(())
+  }
+
+  #[test]
+  fn alias_in_parent_does_not_find_target_in_child() -> Result<(), Error> {
+    let result = testing::config(
+      "
+      aliases:
+        foo: bar
+    ",
+    );
+
+    match result {
+      Err(Error::AliasTargetUnknown { name, target }) => {
+        assert_eq!(name, "foo");
+        assert_eq!(target, "bar");
+      }
+      Err(err) => panic!("unexpected error: {:?}", err),
+      Ok(ok) => panic!("expected error but got: {:?}", ok),
+    }
+
+    Ok(())
+  }
+
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,14 +1,33 @@
 use crate::common::*;
 
 pub(crate) struct Context {
+  parent: Option<Box<Context>>,
+  aliases: BTreeMap<String, String>,
+  templates: BTreeMap<String, String>,
   tera: Tera,
 }
 
 impl Context {
-  pub(crate) fn new(templates: &BTreeMap<String, String>) -> Result<Context, Error> {
+  pub(crate) fn new(config: &Config) -> Result<Context, Error> {
+    let parent = if let Some(parent) = config.parent.as_ref() {
+      Some(Box::new(Context::new(parent)?))
+    } else {
+      None
+    };
+
+    Ok(Context {
+      parent,
+      templates: config.templates.clone(),
+      aliases: config.aliases.clone(),
+      tera: Self::tera(config)?,
+    })
+  }
+
+  fn tera(config: &Config) -> Result<Tera, Error> {
     let mut tera = Tera::default();
 
-    let errors = templates
+    let errors = config
+      .templates
       .iter()
       .flat_map(|(name, text)| {
         tera
@@ -28,26 +47,47 @@ impl Context {
 
     FnCmd.register(&mut tera);
     FnEnv.register(&mut tera);
+    FtJoin.register(&mut tera);
 
-    Ok(Context { tera })
+    Ok(tera)
   }
 
-  pub(crate) fn render(&self, name: &str, query: &str) -> Result<Url, Error> {
-    let mut context = tera::Context::new();
-    context.insert("query", query);
+  pub(crate) fn render(&self, name: &str, args: &[&str]) -> Result<Url, Error> {
+    let target = self
+      .aliases
+      .get(name)
+      .map(|target| target.as_str())
+      .unwrap_or(name);
 
-    let text = self
-      .tera
-      .render(name, context)
-      .map_err(|tera_error| Error::TemplateRender {
+    if self.templates.contains_key(target) {
+      let mut context = tera::Context::new();
+      let args = Value::Array(
+        args
+          .iter()
+          .map(|arg| Value::String(arg.to_string()))
+          .collect(),
+      );
+      context.insert("args", &args);
+
+      let text = self
+        .tera
+        .render(target, context)
+        .map_err(|tera_error| Error::TemplateRender {
+          name: name.to_owned(),
+          tera_error,
+        })?;
+
+      Url::parse(&text).map_err(|url_parse_error| Error::UrlParse {
+        text,
+        url_parse_error,
+      })
+    } else if let Some(parent) = &self.parent {
+      parent.render(target, args)
+    } else {
+      Err(Error::TemplateUnknown {
         name: name.to_owned(),
-        tera_error,
-      })?;
-
-    Url::parse(&text).map_err(|url_parse_error| Error::UrlParse {
-      text,
-      url_parse_error,
-    })
+      })
+    }
   }
 }
 
@@ -57,12 +97,107 @@ mod tests {
 
   #[test]
   fn simple() -> Result<(), Error> {
-    let context = testing::context(vec![("example", "https://example.com/search?q={{query}}")])?;
+    let context = testing::context(vec![(
+      "example",
+      "https://example.com/search?q={{args | join}}",
+    )])?;
 
-    let result = context.render("example", "XYZ")?;
+    let result = context.render("example", &["XYZ"])?;
 
     assert_eq!(result.as_str(), "https://example.com/search?q=XYZ");
 
     Ok(())
   }
+
+  #[test]
+  fn child_template_shadows_parent() -> Result<(), Error> {
+    let config = testing::config(
+      "
+      templates:
+        crates-io: https://foo.rs/{{args | join}}
+    ",
+    )?;
+
+    let query = testing::query("crates-io", &["bar", "baz"]);
+
+    let url = query.render(&config)?;
+
+    assert_eq!(url.to_string(), "https://foo.rs/bar%20baz");
+
+    Ok(())
+  }
+
+  #[test]
+  fn child_alias_finds_child_target() -> Result<(), Error> {
+    let config = testing::config(
+      "
+      aliases:
+        ci: crates-io
+
+      templates:
+        crates-io: https://foo.rs/{{args | join}}
+    ",
+    )?;
+
+    let query = testing::query("ci", &["bar", "baz"]);
+
+    let url = query.render(&config)?;
+
+    assert_eq!(url.to_string(), "https://foo.rs/bar%20baz");
+
+    Ok(())
+  }
+
+  #[test]
+  fn parent_template_resolves() -> Result<(), Error> {
+    let config = testing::config(
+      "
+      root: false
+    ",
+    )?;
+
+    let query = testing::query("crates-io", &["bar", "baz"]);
+
+    let url = query.render(&config)?;
+
+    assert_eq!(url.to_string(), "https://crates.io/search?q=bar%20baz");
+
+    Ok(())
+  }
+
+  #[test]
+  fn child_alias_resolves_to_parent_target() -> Result<(), Error> {
+    let config = testing::config(
+      "
+      aliases:
+        foo: crates-io
+    ",
+    )?;
+
+    let query = testing::query("foo", &["bar", "baz"]);
+
+    let url = query.render(&config)?;
+
+    assert_eq!(url.to_string(), "https://crates.io/search?q=bar%20baz");
+    Ok(())
+  }
+
+  #[test]
+  fn alias_in_parent_ignores_targets_in_child() -> Result<(), Error> {
+    let config = testing::config(
+      "
+      templates:
+        crates-io: https://foo.rs/{{args | join}}
+    ",
+    )?;
+
+    let query = testing::query("ci", &["bar", "baz"]);
+
+    let url = query.render(&config)?;
+
+    assert_eq!(url.to_string(), "https://crates.io/search?q=bar%20baz");
+
+    Ok(())
+  }
+
 }

--- a/src/default_config.rs
+++ b/src/default_config.rs
@@ -1,0 +1,1 @@
+pub(crate) const DEFAULT_CONFIG: &str = include_str!("../odin.yaml");

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,14 +2,20 @@ use crate::common::*;
 
 #[derive(Debug)]
 pub(crate) enum Error {
-  ConfigMissing,
   ConfigDeserialize {
-    path: PathBuf,
+    location: Location,
+    yaml_error: serde_yaml::Error,
+  },
+  ConfigSerialize {
     yaml_error: serde_yaml::Error,
   },
   ConfigIo {
     path: PathBuf,
     io_error: io::Error,
+  },
+  AliasTargetUnknown {
+    name: String,
+    target: String,
   },
   TemplateUnknown {
     name: String,

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,0 +1,51 @@
+use crate::common::*;
+
+use tera::{Map, Value};
+
+type Boxed =
+  Box<dyn Fn(&Value, &HashMap<String, Value>) -> Result<Value, tera::Error> + Send + Sync>;
+
+pub(crate) trait Filter: Send + Sync + Sized + 'static {
+  type Arguments: DeserializeOwned;
+  type Input: DeserializeOwned;
+
+  fn name(&self) -> &'static str;
+
+  fn usage(&self) -> &'static str;
+
+  fn call(&self, input: Self::Input, args: Self::Arguments) -> Result<Value, String>;
+
+  fn register(self, tera: &mut Tera) {
+    tera.register_filter(self.name(), self.boxed())
+  }
+
+  fn boxed(self) -> Boxed {
+    Box::new(move |value, args| self.dispatch(value, args))
+  }
+
+  fn dispatch(&self, input: &Value, args: &HashMap<String, Value>) -> Result<Value, tera::Error> {
+    let map = Map::from_iter(args.clone().into_iter());
+
+    let args: Value = Value::Object(map);
+
+    let args: Self::Arguments = serde_json::from_value(args).map_err(|serde_json_error| {
+      format!(
+        "usage: {}({}): {}",
+        self.name(),
+        self.usage(),
+        serde_json_error
+      )
+    })?;
+
+    let input: Self::Input = serde_json::from_value(input.clone()).map_err(|serde_json_error| {
+      format!(
+        "usage: {}({}): {}",
+        self.name(),
+        self.usage(),
+        serde_json_error
+      )
+    })?;
+
+    self.call(input, args).map_err(tera::Error::msg)
+  }
+}

--- a/src/ft_join.rs
+++ b/src/ft_join.rs
@@ -1,0 +1,35 @@
+use crate::common::*;
+
+use tera::Value;
+
+pub(crate) struct FtJoin;
+
+#[derive(Deserialize)]
+pub(crate) struct Arguments {
+  sep: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(transparent)]
+pub(crate) struct Input {
+  values: Vec<String>,
+}
+
+impl Filter for FtJoin {
+  type Arguments = Arguments;
+  type Input = Input;
+
+  fn name(&self) -> &'static str {
+    "join"
+  }
+
+  fn usage(&self) -> &'static str {
+    r#"sep=SEPARATOR""#
+  }
+
+  fn call(&self, input: Self::Input, args: Self::Arguments) -> Result<Value, String> {
+    let separator = args.sep.as_ref().map(|sep| sep.as_str()).unwrap_or(" ");
+
+    Ok(Value::String(input.values.join(separator)))
+  }
+}

--- a/src/location.rs
+++ b/src/location.rs
@@ -1,0 +1,23 @@
+use crate::common::*;
+
+#[derive(Debug)]
+pub(crate) enum Location {
+  Name { name: String },
+  Path { path: PathBuf },
+}
+
+impl Location {
+  pub(crate) fn name(name: impl ToString) -> Location {
+    Location::Name {
+      name: name.to_string(),
+    }
+  }
+}
+
+impl<P: AsRef<Path>> From<P> for Location {
+  fn from(path: P) -> Location {
+    Location::Path {
+      path: path.as_ref().to_owned(),
+    }
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,17 @@
 mod common;
 mod config;
 mod context;
+mod default_config;
 mod error;
+mod filter;
 mod fn_cmd;
 mod fn_env;
+mod ft_join;
 mod function;
+mod location;
 mod opt;
+mod query;
+mod subcommand;
 mod template_parse_error;
 
 #[cfg(test)]
@@ -14,36 +20,5 @@ mod testing;
 use crate::common::*;
 
 fn main() -> Result<(), Error> {
-  let opt = Opt::from_args();
-
-  let config_path = opt.config_path()?;
-
-  let config = Config::load(&config_path)?;
-
-  let context = Context::new(&config.templates)?;
-
-  let template = config.resolve(&opt.template)?;
-
-  let url = context.render(template, &opt.query)?;
-
-  if opt.print {
-    println!("{}", url.as_str());
-    return Ok(());
-  }
-
-  let output = webbrowser::open(&url.as_str()).map_err(|io_error| Error::BrowserOpen {
-    url: url.clone(),
-    io_error,
-  })?;
-
-  if !output.status.success() {
-    return Err(Error::BrowserExitStatus {
-      url: url.clone(),
-      exit_status: output.status,
-      stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-      stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-    });
-  }
-
-  Ok(())
+  Opt::from_args().run()
 }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -2,26 +2,16 @@ use crate::common::*;
 
 #[derive(StructOpt)]
 pub(crate) struct Opt {
-  #[structopt(name = "TEMPLATE")]
-  pub(crate) template: String,
-  #[structopt(name = "QUERY")]
-  pub(crate) query: String,
   #[structopt(name = "CONFIG", long = "--config")]
-  pub(crate) config_path: Option<PathBuf>,
-  #[structopt(name = "PRINT", long = "print")]
-  pub(crate) print: bool,
+  config_path: Option<PathBuf>,
+  #[structopt(subcommand)]
+  subcommand: Subcommand,
 }
 
 impl Opt {
-  pub(crate) fn config_path(&self) -> Result<PathBuf, Error> {
-    if let Some(config_path) = &self.config_path {
-      return Ok(config_path.clone());
-    }
+  pub(crate) fn run(self) -> Result<(), Error> {
+    let config = Config::load(self.config_path)?;
 
-    let base_directories = BaseDirectories::new()?;
-
-    base_directories
-      .find_config_file(Config::FILE_NAME)
-      .ok_or(Error::ConfigMissing)
+    self.subcommand.run(&config)
   }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,0 +1,21 @@
+use crate::common::*;
+
+#[derive(StructOpt)]
+pub(crate) struct Query {
+  #[structopt(name = "TEMPLATE")]
+  pub(crate) name: String,
+  #[structopt(name = "QUERY")]
+  pub(crate) args: Vec<String>,
+}
+
+impl Query {
+  pub(crate) fn render(&self, config: &Config) -> Result<Url, Error> {
+    let context = Context::new(&config)?;
+
+    let args = self.args.iter().map(AsRef::as_ref).collect::<Vec<&str>>();
+
+    let url = context.render(&self.name, &args)?;
+
+    Ok(url)
+  }
+}

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -1,0 +1,25 @@
+use crate::common::*;
+
+pub(crate) mod dump;
+pub(crate) mod open;
+pub(crate) mod print;
+
+#[derive(StructOpt)]
+pub(crate) enum Subcommand {
+  #[structopt(name = "open")]
+  Open(open::Open),
+  #[structopt(name = "print")]
+  Print(print::Print),
+  #[structopt(name = "dump")]
+  Dump(dump::Dump),
+}
+
+impl Subcommand {
+  pub(crate) fn run(self, config: &Config) -> Result<(), Error> {
+    match self {
+      Self::Print(print) => print.run(config),
+      Self::Open(open) => open.run(config),
+      Self::Dump(dump) => dump.run(config),
+    }
+  }
+}

--- a/src/subcommand/dump.rs
+++ b/src/subcommand/dump.rs
@@ -1,0 +1,74 @@
+use crate::common::*;
+
+#[derive(StructOpt)]
+pub(crate) struct Dump {}
+
+impl Dump {
+  pub(crate) fn run(self, config: &Config) -> Result<(), Error> {
+    println!("{}", Self::format(config)?);
+    Ok(())
+  }
+
+  pub(crate) fn format(config: &Config) -> Result<String, Error> {
+    #[derive(Serialize)]
+    struct Pretty<'config> {
+      templates: Option<&'config BTreeMap<String, String>>,
+      #[serde(skip_serializing_if = "Option::is_none")]
+      aliases: Option<&'config BTreeMap<String, String>>,
+    }
+
+    let pretty = Pretty {
+      aliases: Some(&config.aliases).filter(|aliases| !aliases.is_empty()),
+      templates: Some(&config.templates).filter(|templates| !templates.is_empty()),
+    };
+
+    let yaml =
+      serde_yaml::to_string(&pretty).map_err(|yaml_error| Error::ConfigSerialize { yaml_error })?;
+
+    let yaml = yaml.replace("\naliases:\n", "\n\naliases:\n");
+
+    Ok(yaml.trim_start_matches("---\n").to_owned())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn templates() -> Result<(), Error> {
+    let config = testing::config(
+      "
+      templates:
+        foo: http://bar.com/{{query}}
+    ",
+    )?;
+
+    assert_eq!(
+      Dump::format(&config)?,
+      "templates:\n  foo: \"http://bar.com/{{query}}\""
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn templates_and_aliases() -> Result<(), Error> {
+    let config = testing::config(
+      "
+      aliases:
+        bar: foo
+
+      templates:
+        foo: http://bar.com/{{query}}
+    ",
+    )?;
+
+    assert_eq!(
+      Dump::format(&config)?,
+      "templates:\n  foo: \"http://bar.com/{{query}}\"\n\naliases:\n  bar: foo"
+    );
+
+    Ok(())
+  }
+}

--- a/src/subcommand/open.rs
+++ b/src/subcommand/open.rs
@@ -1,0 +1,29 @@
+use crate::common::*;
+
+#[derive(StructOpt)]
+pub(crate) struct Open {
+  #[structopt(flatten)]
+  query: Query,
+}
+
+impl Open {
+  pub(crate) fn run(self, config: &Config) -> Result<(), Error> {
+    let url = self.query.render(config)?;
+
+    let output = webbrowser::open(&url.as_str()).map_err(|io_error| Error::BrowserOpen {
+      url: url.clone(),
+      io_error,
+    })?;
+
+    if !output.status.success() {
+      return Err(Error::BrowserExitStatus {
+        url: url.clone(),
+        exit_status: output.status,
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+      });
+    }
+
+    Ok(())
+  }
+}

--- a/src/subcommand/print.rs
+++ b/src/subcommand/print.rs
@@ -1,0 +1,17 @@
+use crate::common::*;
+
+#[derive(StructOpt)]
+pub(crate) struct Print {
+  #[structopt(flatten)]
+  query: Query,
+}
+
+impl Print {
+  pub(crate) fn run(self, config: &Config) -> Result<(), Error> {
+    let url = self.query.render(config)?;
+
+    println!("{}", url);
+
+    Ok(())
+  }
+}

--- a/tests/cmd_function.rs
+++ b/tests/cmd_function.rs
@@ -27,13 +27,13 @@ macro_rules! case {
       let output = Command::new(executable)
         .arg("--config")
         .arg(config_path)
-        .arg("--print")
+        .arg("print")
         .arg("foo")
         .arg("baz")
         .output()?;
 
       if !output.status.success() {
-        panic!("odin invocation failed with status {}");
+        panic!("odin invocation failed with status: {}", output.status);
       }
 
       let have = String::from_utf8_lossy(&output.stdout).into_owned();
@@ -49,7 +49,7 @@ case! {
   name:  echo,
   config: r#"
     templates:
-      foo: https://{{cmd(bin="echo", args=["bar"])}}.{{query}}.com
+      foo: https://{{cmd(bin="echo", args=["bar"])}}.{{args | join}}.com
   "#,
   stdout: "https://bar.baz.com/\n",
 }

--- a/tests/default_templates.rs
+++ b/tests/default_templates.rs
@@ -27,9 +27,9 @@ fn print(template: &str, query: &str) -> io::Result<String> {
   let executable = executable_path("odin");
 
   let output = Command::new(executable)
-    .arg("--config")
-    .arg("odin.yaml")
-    .arg("--print")
+    // .arg("--config")
+    // .arg("odin.yaml")
+    .arg("print")
     .arg(template)
     .arg(query)
     .output()?;
@@ -37,6 +37,7 @@ fn print(template: &str, query: &str) -> io::Result<String> {
   Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
+#[allow(unused)]
 fn cmd(bin: &str, args: &[&str]) -> String {
   let output = Command::new(bin).args(args).output().unwrap();
 
@@ -62,11 +63,4 @@ case! {
   template: "github",
   query:    "just",
   rendered: "https://github.com/search?q=just\n",
-}
-
-case! {
-  name:     rustup_stdlib,
-  template: "rustup-stdlib",
-  query:    "str::fix_my_spelling_mistakes",
-  rendered: format!("file://{}", cmd("rustup", &["doc", "--std", "--path"])),
 }


### PR DESCRIPTION
- Capture trailing args and pass as array to template
- Add `join` filter with ' ' as default separator, for joining args into
  query strings
- Add `install` and `clippy` just recipes
- Add config inheritance
- Add a dump command that prints out config

Fixes: #8, #7, and #4